### PR TITLE
Feature/check container when adding item to player

### DIFF
--- a/data/scripts/talkactions/god/create_item.lua
+++ b/data/scripts/talkactions/god/create_item.lua
@@ -41,19 +41,14 @@ function createItem.onSay(player, words, param)
 		end
 	end
 
-	local result = player:addItem(itemType:getId(), count)
-	if result then
+	local item = Game.createItem(itemType:getId(), 1)
+	if player:addItemEx(item) then
 		if not itemType:isStackable() then
-			if type(result) == "table" then
-				for _, item in ipairs(result) do
-					item:decay()
-				end
-			else
-				result:decay()
-			end
+			item:decay()
 		end
 		player:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)
 	end
+	player:sendCancelMessage("Your backpack is full.")
 	return false
 end
 

--- a/data/scripts/talkactions/god/create_item.lua
+++ b/data/scripts/talkactions/god/create_item.lua
@@ -42,13 +42,15 @@ function createItem.onSay(player, words, param)
 	end
 
 	local item = Game.createItem(itemType:getId(), 1)
-	if player:addItemEx(item) then
+	local returnValue = player:addItemEx(item)
+	if returnValue == RETURNVALUE_NOERROR then
 		if not itemType:isStackable() then
 			item:decay()
 		end
 		player:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)
+		return
 	end
-	player:sendCancelMessage("Your backpack is full.")
+	player:sendCancelMessage(returnValue)
 	return false
 end
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9408,8 +9408,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 
 int LuaScriptInterface::luaPlayerAddItemEx(lua_State* L)
 {
-	// player:addItemEx(item[, canDropOnMap = false[, index = INDEX_WHEREEVER[, flags = 0]]])
-	// player:addItemEx(item[, canDropOnMap = true[, slot = CONST_SLOT_WHEREEVER]])
+	// player:addItemEx(item[, canDropOnMap, slot = CONST_SLOT_WHEREEVER]])
 	Item* item = getUserdata<Item>(L, 2);
 	if (!item) {
 		reportErrorFunc(getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
@@ -9430,15 +9429,8 @@ int LuaScriptInterface::luaPlayerAddItemEx(lua_State* L)
 	}
 
 	bool canDropOnMap = getBoolean(L, 3, false);
-	ReturnValue returnValue;
-	if (canDropOnMap) {
-		slots_t slot = getNumber<slots_t>(L, 4, CONST_SLOT_WHEREEVER);
-		returnValue = g_game().internalPlayerAddItem(player, item, true, slot);
-	} else {
-		int32_t index = getNumber<int32_t>(L, 4, INDEX_WHEREEVER);
-		uint32_t flags = getNumber<uint32_t>(L, 5, 0);
-		returnValue = g_game().internalAddItem(player, item, index, flags);
-	}
+  slots_t slot = getNumber<slots_t>(L, 4, CONST_SLOT_WHEREEVER);
+  ReturnValue returnValue = g_game().internalPlayerAddItem(player, item, canDropOnMap, slot);
 
 	if (returnValue == RETURNVALUE_NOERROR) {
 		ScriptEnvironment::removeTempItem(item);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2470,7 +2470,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 
 		case CONST_SLOT_BACKPACK: {
 			if (slotPosition & SLOTP_BACKPACK) {
-				ret = RETURNVALUE_NOERROR;
+				ret = containerQueryAdd(item, static_cast<slots_t>(index));
 			}
 			break;
 		}
@@ -2624,10 +2624,29 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 		return RETURNVALUE_NOTENOUGHCAPACITY;
 	}
 
-	if (!g_moveEvents().onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item), static_cast<slots_t>(index), true)) {
-		return RETURNVALUE_CANNOTBEDRESSED;
-	}
-	return ret;
+	return static_cast<ReturnValue>(g_moveEvents().onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item), static_cast<slots_t>(index), true));
+}
+
+ReturnValue Player::containerQueryAdd(const Item* item, slots_t slot) const
+{
+    if (!item) {
+        return RETURNVALUE_NOTPOSSIBLE;
+    }
+
+    if (slot != CONST_SLOT_BACKPACK && slot > CONST_SLOT_WHEREEVER) {
+      return RETURNVALUE_NOERROR;
+    }
+
+    Item *bp = getInventoryItem(CONST_SLOT_BACKPACK);
+	  if (!bp) {
+		  return RETURNVALUE_NOERROR;
+	  }
+	
+	  if (Container *container = bp->getContainer()){
+		  return container->queryAdd(INDEX_WHEREEVER, *item, 1, 0);
+	  }
+
+    return RETURNVALUE_NOERROR;
 }
 
 ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2637,10 +2637,14 @@ ReturnValue Player::containerQueryAdd(const Item* item, slots_t slot) const
       return RETURNVALUE_NOERROR;
     }
 
+    bool isBackpack = item->getSlotPosition() & SLOTP_BACKPACK;
     Item *bp = getInventoryItem(CONST_SLOT_BACKPACK);
-	  if (!bp) {
-		  return RETURNVALUE_NOERROR;
-	  }
+	  if (!bp && !isBackpack) {
+		  return RETURNVALUE_NOTENOUGHROOM;
+    }
+    else if (isBackpack) {
+      return RETURNVALUE_NOERROR;
+    }
 	
 	  if (Container *container = bp->getContainer()){
 		  return container->queryAdd(INDEX_WHEREEVER, *item, 1, 0);

--- a/src/player.h
+++ b/src/player.h
@@ -1354,6 +1354,8 @@ class Player final : public Creature, public Cylinder
 			scheduledUpdate = false;
 		}
 
+		ReturnValue containerQueryAdd(const Item* item, slots_t slot) const;
+
 	private:
 		std::vector<Condition*> getMuteConditions() const;
 


### PR DESCRIPTION
Fix container addition bug, where player has no space and it CANNOT drop on the floor, then it gets created in a "void" situation, not in the player, not in a container, not in the floor. Potentially a memory leak.